### PR TITLE
ci: Update workflow to use pre-built docker containers

### DIFF
--- a/.github/workflows/distcheck-single-container.yaml
+++ b/.github/workflows/distcheck-single-container.yaml
@@ -1,0 +1,44 @@
+name: PR CI Single Run
+on: workflow_dispatch
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    container: 
+      image: ghcr.io/${{ github.repository }}/aws-ofi-nccl-dev:latest
+      credentials:
+         username: ${{ github.actor }}
+         password: ${{ secrets.GITHUB_TOKEN }}
+    name: build-test-job
+    steps:
+      - uses: actions/checkout@v3
+      
+      # Since all dependencies are now in the container, you can remove these steps:
+      # - Install EFA Installer Dependencies
+      # - Install hwloc, utilities
+      # - Install CUDA
+      
+      - name: Call `autoreconf -ivf`
+        run: |
+          ./autogen.sh
+
+      - name: Run Configure
+        run: |
+          ./configure --with-mpi=/opt/amazon/openmpi \
+                     --with-libfabric=/opt/amazon/efa \
+                     --enable-tests=yes \
+                     --enable-werror=yes \
+                     --enable-picky-compiler=yes \
+                     --enable-platform-aws \
+                     --with-cuda=/usr/local/cuda/
+
+      - name: Call `make`
+        run: make V=1
+
+      - name: Call `make check`
+        run: make check V=1 || (cat tests/unit/test-suite.log && exit 1)
+
+      - name: Call `make install`
+        run: make install V=1
+
+      - name: Call `make distcheck`
+        run: make distcheck V=1

--- a/.github/workflows/distcheck-single.yaml
+++ b/.github/workflows/distcheck-single.yaml
@@ -1,0 +1,56 @@
+name: PR CI Single Run
+on: workflow_dispatch
+jobs:
+  build-test:
+    runs-on: ubuntu-latest  # This is ignored by act, but kept for GitHub Actions compatibility
+    container: public.ecr.aws/amazonlinux/amazonlinux:2023
+    name: build-test-job
+    steps:
+      - run: |
+          yum -y update && yum -y install git tar util-linux findutils yum-utils
+      - uses: actions/checkout@v3
+      
+      - name: Fetch and Install EFA Installer Dependencies
+        run: |
+          curl -O https://efa-installer.amazonaws.com/aws-efa-installer-latest.tar.gz
+          tar -xf aws-efa-installer-*.tar.gz
+          cd aws-efa-installer/RPMS/ALINUX2023/x86_64
+          find . | grep rpm$ | xargs yum -y localinstall
+
+      - name: Install hwloc, utilities
+        run: |
+          yum -y install hwloc-devel autoconf automake libtool gcc gcc-c++ git make
+
+      - name: Install CUDA
+        run: |
+          dnf config-manager --add-repo \
+             http://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/cuda-amzn2023.repo \
+             --save
+          yum -y clean expire-cache
+          yum -y install cuda-cudart-devel-12-6 cuda-crt-12-6
+
+      - name: Call `autoreconf -ivf`
+        run: |
+          ./autogen.sh
+
+      - name: Run Configure
+        run: |
+          ./configure --with-mpi=/opt/amazon/openmpi \
+                     --with-libfabric=/opt/amazon/efa \
+                     --enable-tests=yes \
+                     --enable-werror=yes \
+                     --enable-picky-compiler=yes \
+                     --enable-platform-aws \
+                     --with-cuda=/usr/local/cuda/
+
+      - name: Call `make`
+        run: make V=1
+
+      - name: Call `make check`
+        run: make check V=1 || (cat tests/unit/test-suite.log && exit 1)
+
+      - name: Call `make install`
+        run: make install V=1
+
+      - name: Call `make distcheck`
+        run: make distcheck V=1

--- a/.github/workflows/update-containers.yaml
+++ b/.github/workflows/update-containers.yaml
@@ -1,0 +1,47 @@
+name: Update CI Containers
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Weekly
+  workflow_dispatch:
+
+jobs:
+  update-container:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/aws-ofi-nccl-dev
+          tags: |
+            type=raw,value=latest
+            type=sha
+            type=ref,event=branch
+            type=ref,event=tag
+      
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Dockerfile.al2023
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile.al2023
+++ b/Dockerfile.al2023
@@ -1,0 +1,41 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+
+# Install base packages
+RUN yum -y update && \
+    yum -y install \
+    git \
+    tar \
+    util-linux \
+    findutils \
+    yum-utils \
+    hwloc-devel \
+    autoconf \
+    automake \
+    libtool \
+    gcc \
+    gcc-c++ \
+    make \
+    # Clean yum cache to reduce image size
+    && yum clean all \
+    && rm -rf /var/cache/yum
+
+# Install CUDA
+RUN dnf config-manager --add-repo \
+    http://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/cuda-amzn2023.repo \
+    --save && \
+    yum -y clean expire-cache && \
+    yum -y install cuda-cudart-devel-12-6 cuda-crt-12-6 && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+# Pre-install base EFA components
+RUN curl -O https://efa-installer.amazonaws.com/aws-efa-installer-latest.tar.gz && \
+    tar -xf aws-efa-installer-*.tar.gz && \
+    cd aws-efa-installer/RPMS/ALINUX2023/x86_64 && \
+    find . | grep rpm$ | xargs yum -y localinstall && \
+    cd / && \
+    rm -rf aws-efa-installer* && \
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+WORKDIR /workspace


### PR DESCRIPTION
*Description of changes:*

Currently the github actions workflow installs all the packages during runtime. Instead we want to install all the packages except efa-installer and aws-ofi-nccl plugin within a docker container and use this container during runtime.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
