### PR TITLE
ci: Update workflow to use pre-built docker containers

### DIFF
--- a/.github/workflows/distcheck-single-container.yaml
+++ b/.github/workflows/distcheck-single-container.yaml
@@ -1,4 +1,4 @@
-name: Containerized PR CI Single Run
+name: PR CI Single Run Containerized
 on: workflow_dispatch
 jobs:
   build-test:


### PR DESCRIPTION
Currently the github actions workflow installs all the packages during runtime. Instead we want to install all the packages except efa-installer and aws-ofi-nccl plugin within a docker container and use this container during runtime.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
